### PR TITLE
API Endpoint

### DIFF
--- a/octoprint_DisplayLayerProgress/__init__.py
+++ b/octoprint_DisplayLayerProgress/__init__.py
@@ -686,20 +686,17 @@ class DisplaylayerprogressPlugin(
 
                 return flask.jsonify(self.get_settings_defaults())
 
-            if "data" == action:
-                return flask.jsonify(
-                    layerTotalCount = self._layerTotalCount,
-                    currentLayer = self._currentLayer,
-                    progress = self._progress,
-                    currentHeight = self._currentHeight,
-                    totalHeightWithExtrusion = self._totalHeightWithExtrusion,
-                    totalHeight = self._totalHeight,
-                    feedrate = self._feedrate,
-                    fanSpeed = self._fanSpeed
-                )
-
-        # default/other action
-        self._updateDisplay(UPDATE_DISPLAY_REASON_FRONTEND_CALL)
+        # return data via the default API endpoint
+        return flask.jsonify(
+            layerTotalCount = self._layerTotalCount,
+            currentLayer = self._currentLayer,
+            progress = self._progress,
+            currentHeight = self._currentHeight,
+            totalHeightWithExtrusion = self._totalHeightWithExtrusion,
+            totalHeight = self._totalHeight,
+            feedrate = self._feedrate,
+            fanSpeed = self._fanSpeed
+        )
 
 
     # ~~ TemplatePlugin mixin

--- a/octoprint_DisplayLayerProgress/__init__.py
+++ b/octoprint_DisplayLayerProgress/__init__.py
@@ -687,16 +687,19 @@ class DisplaylayerprogressPlugin(
                 return flask.jsonify(self.get_settings_defaults())
 
         # return data via the default API endpoint
-        return flask.jsonify(
-            layerTotalCount = self._layerTotalCount,
-            currentLayer = self._currentLayer,
-            progress = self._progress,
-            currentHeight = self._currentHeight,
-            totalHeightWithExtrusion = self._totalHeightWithExtrusion,
-            totalHeight = self._totalHeight,
-            feedrate = self._feedrate,
-            fanSpeed = self._fanSpeed
-        )
+        return flask.jsonify({
+            "layer": {
+                "total": self._layerTotalCount,
+                "current": self._currentLayer
+            },
+            "height": {
+                "total": self._totalHeight,
+                "totalWithExtrusion": self._totalHeightWithExtrusion,
+                "current": self._currentHeight
+            },
+            "fanSpeed": self._fanSpeed,
+            "feedrate": self._feedrate
+        })
 
 
     # ~~ TemplatePlugin mixin

--- a/octoprint_DisplayLayerProgress/__init__.py
+++ b/octoprint_DisplayLayerProgress/__init__.py
@@ -671,6 +671,11 @@ class DisplaylayerprogressPlugin(
         #update new settings
         self._updateDisplay(UPDATE_DISPLAY_REASON_FRONTEND_CALL)
 
+    def get_api_commands(self):
+        return dict(
+            command1=[]
+        )
+
     # to allow the frontend to trigger an update
     def on_api_get(self, request):
         if len(request.values) != 0:
@@ -688,6 +693,16 @@ class DisplaylayerprogressPlugin(
 
         # default/other action
         self._updateDisplay(UPDATE_DISPLAY_REASON_FRONTEND_CALL)
+        return flask.jsonify(
+            layerTotalCount = self._layerTotalCount,
+            currentLayer = self._currentLayer,
+            progress = self._progress,
+            currentHeight = self._currentHeight,
+            totalHeightWithExtrusion = self._totalHeightWithExtrusion,
+            totalHeight = self._totalHeight,
+            feedrate = self._feedrate,
+            fanSpeed = self._fanSpeed
+        )
 
     # ~~ TemplatePlugin mixin
     def get_template_configs(self):

--- a/octoprint_DisplayLayerProgress/__init__.py
+++ b/octoprint_DisplayLayerProgress/__init__.py
@@ -671,11 +671,6 @@ class DisplaylayerprogressPlugin(
         #update new settings
         self._updateDisplay(UPDATE_DISPLAY_REASON_FRONTEND_CALL)
 
-    def get_api_commands(self):
-        return dict(
-            command1=[]
-        )
-
     # to allow the frontend to trigger an update
     def on_api_get(self, request):
         if len(request.values) != 0:
@@ -691,18 +686,21 @@ class DisplaylayerprogressPlugin(
 
                 return flask.jsonify(self.get_settings_defaults())
 
+            if "data" == action:
+                return flask.jsonify(
+                    layerTotalCount = self._layerTotalCount,
+                    currentLayer = self._currentLayer,
+                    progress = self._progress,
+                    currentHeight = self._currentHeight,
+                    totalHeightWithExtrusion = self._totalHeightWithExtrusion,
+                    totalHeight = self._totalHeight,
+                    feedrate = self._feedrate,
+                    fanSpeed = self._fanSpeed
+                )
+
         # default/other action
         self._updateDisplay(UPDATE_DISPLAY_REASON_FRONTEND_CALL)
-        return flask.jsonify(
-            layerTotalCount = self._layerTotalCount,
-            currentLayer = self._currentLayer,
-            progress = self._progress,
-            currentHeight = self._currentHeight,
-            totalHeightWithExtrusion = self._totalHeightWithExtrusion,
-            totalHeight = self._totalHeight,
-            feedrate = self._feedrate,
-            fanSpeed = self._fanSpeed
-        )
+
 
     # ~~ TemplatePlugin mixin
     def get_template_configs(self):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_DisplayLayerProgress"
 plugin_name = "DisplayLayerProgress"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.11.0"
+plugin_version = "1.11.1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
I've added a simple API to retrieve the data your plugin collects. I've tried to match the style of the Octoprint APIs in some way.

I think I've included everything that needs to be exposed via an API, I don't know what FeedrateG0 and FeedrateG1 are, though. If they are needed just let me know and I will add them.

This also closes #79.