### PR TITLE
Fix Total Height Calculation from PrusaSlicer

### DIFF
--- a/octoprint_DisplayLayerProgress/__init__.py
+++ b/octoprint_DisplayLayerProgress/__init__.py
@@ -62,7 +62,7 @@ LAYER_MESSAGE_PREFIX = "M117 INDICATOR-Layer"
 LAYER_COUNT_EXPRESSION = ".*\n?" +LAYER_MESSAGE_PREFIX + "([0-9]*)"
 
 # Match G1 Z149.370 F1000 or G0 F9000 X161.554 Y118.520 Z14.950     ##no comments
-Z_HEIGHT_EXPRESSION = "^[^;](.*)( Z)([+]*[0-9]+[.]*[0-9]*)(.*)"
+Z_HEIGHT_EXPRESSION = "^G[0|1](.*)( Z)([+]*[0-9]+[.]*[0-9]*)(.*)"
 zHeightPattern = re.compile(Z_HEIGHT_EXPRESSION)
 
 # Match G0 or G1 positive extrusion e.g. G1 X58.030 Y72.281 E0.1839 F2250


### PR DESCRIPTION
PrusaSlicer adds several commands to the GCODE file that are mistakenly picked up by the Z_HEIGHT_EXPRESSION:

```
M201 X9000 Y9000 Z500 E10000 ; sets maximum accelerations, mm/sec^2
M203 X500 Y500 Z12 E120 ; sets maximum feedrates, mm/sec
M205 X10.00 Y10.00 Z0.20 E2.50 ; sets the jerk limits, mm/sec
```

With this, my Total Height calculation is always evaluated to be 500mm.

Please see attached pre & post gcode files.

[Gcode files from OctoPrint.zip](https://github.com/OllisGit/OctoPrint-DisplayLayerProgress/files/4142487/Gcode.files.from.OctoPrint.zip)

