### PR TITLE
Add support for Prusa layer counting. 

### DIFF
--- a/octoprint_DisplayLayerProgress/__init__.py
+++ b/octoprint_DisplayLayerProgress/__init__.py
@@ -1610,6 +1610,7 @@ class DisplaylayerprogressPlugin(
                              "1\t\t[;LAYER:([0-9]+).*]\t\tideaMaker\r\n" +
                              "count\t[; BEGIN_LAYER_OBJECT.*]\t\tKISSlicer\r\n" +
                              "count\t[;BEFORE_LAYER_CHANGE]\t\tSlic3r",
+                             "count\t[;LAYER_CHANGE]\t\tPrusa",
             # showLayerInStatusBar=True,
             # showHeightInStatusBar=True,
             updatePrinterDisplayWhilePrinting=False,

--- a/octoprint_DisplayLayerProgress/__init__.py
+++ b/octoprint_DisplayLayerProgress/__init__.py
@@ -1609,7 +1609,7 @@ class DisplaylayerprogressPlugin(
                              "1\t\t[; layer ([0-9]+),.*]\t\tSimplify3D\r\n" +
                              "1\t\t[;LAYER:([0-9]+).*]\t\tideaMaker\r\n" +
                              "count\t[; BEGIN_LAYER_OBJECT.*]\t\tKISSlicer\r\n" +
-                             "count\t[;BEFORE_LAYER_CHANGE]\t\tSlic3r",
+                             "count\t[;BEFORE_LAYER_CHANGE]\t\tSlic3r\r\n" +
                              "count\t[;LAYER_CHANGE]\t\tPrusa",
             # showLayerInStatusBar=True,
             # showHeightInStatusBar=True,


### PR DESCRIPTION
Add support for Prusa without need for asking folks to have script in prusa to add layers.
This works with lastest Prusa (i don't know how far back Prusa was adding `;[LAYER_CHANGE]` as I am relatively new to 3D printing.

My only concern would be what happens to folks who have already configured some other approach?

here is it working:
![image](https://user-images.githubusercontent.com/11369180/134059681-19cf0da1-400c-4c1f-974c-ea3d681a1049.png)
